### PR TITLE
add standard library and separate toolchain from main

### DIFF
--- a/src/vm/oogavm-heap.ts
+++ b/src/vm/oogavm-heap.ts
@@ -7,10 +7,6 @@ const log = debug('ooga:memory');
 // number of bytes each word represents
 const wordSize = 8;
 
-const sizeOffset = 5;
-
-const emptyFreeList = -1;
-
 export enum Tag {
     UNINITIALIZED, // all starting heap are tag 0
     FALSE,
@@ -77,8 +73,8 @@ function getTagString(tag: Tag): string {
 //  4-7th byte: tag of node
 // 2nd word is the forwarding address
 // 3rd word onwards is tag dependent interpretation
-// For Tags without children, payload is the 3rd word
-// For Tags with children, num children is 3rd word
+// Payload is the 3rd word for all tags
+// 3rd word onwards is the children
 //
 // minimum number of words required to support each node in the
 // linear list is = 3 words
@@ -860,6 +856,7 @@ function moveLiveObjects() {
 let roots: number[][] = [];
 let rootMappings = new Map<number, number>();
 
+// Lisp 2 Garbage Collection!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 function collectGarbage() {
     // First pass: marking
     log('Collecting da garbage...');

--- a/src/vm/oogavm-machine.ts
+++ b/src/vm/oogavm-machine.ts
@@ -3,7 +3,6 @@ import * as util from 'util';
 import { RoundRobinScheduler, Scheduler, ThreadId } from './oogavm-scheduler.js';
 import { fileURLToPath } from 'url';
 import debug from 'debug';
-import { HeapDeadError, HeapOutOfMemoryError } from './oogavm-errors.js';
 import {
     addressToTSValue,
     allocateBlockFrame,
@@ -198,6 +197,7 @@ export function initializeBuiltinTable() {
 }
 
 function applyBuiltin(builtinId: number) {
+    // @ts-ignore
     const result = [builtinArray[builtinId]()];
     let _;
     [OS[0], _] = popStack(OS[0]); // pop fun
@@ -655,6 +655,8 @@ function initialize(numWords = 1000000) {
     running = true;
     State = ProgramState.NORMAL;
     initScheduler();
+    log("After initializing: ");
+    printHeapUsage();
 }
 
 function initializeBuiltins() {
@@ -708,6 +710,9 @@ export function run(numWords = 1000000) {
     }
     const returnValue = addressToTSValue(peekStack(OS[0]));
     log('Program value is ' + returnValue);
+    log("After STD initialization: ");
+    printHeapUsage();
+    console.log("Return value: " + returnValue);
     return returnValue;
 }
 

--- a/src/vm/oogavm-toolchain.ts
+++ b/src/vm/oogavm-toolchain.ts
@@ -1,0 +1,39 @@
+import { parse } from '../parser/ooga.js';
+import { checkTypes } from './oogavm-typechecker.js';
+import { compile_program } from './oogavm-compiler.js';
+import { assemble } from './oogavm-assembler.js';
+
+import debug from 'debug';
+
+const log = debug('ooga:vm');
+
+
+// Common utility function to prepare the program for compilation
+export function prepare_and_compile(standardSource: string, programString: string) {
+    const source = programString.trimEnd();
+    let userProgram = parse(source);
+    // If user program parses properly
+    standardSource = standardSource.trim();
+    let standardProgram = parse(standardSource);
+    // wrap up the user program in a block statement
+    userProgram = { tag: 'BlockStatement', body: userProgram };
+    // This pushes the user program as the final block statement
+    // onto the sequence statement of the oogavm-std library
+    // This creates a separate frame for the user program that extends the
+    // User block program
+    // Design speaking wise, this just allows the user to redefine names
+    // in the standard library and it's just a matter of preference
+    standardProgram["body"].push(userProgram);
+    let program = { tag: 'BlockStatement', body: standardProgram};
+    log('--------------------------------------------');
+    log('Parsed program:');
+    log(JSON.stringify(program, null, 2));
+    program = checkTypes(program);
+    log('--------------------------------------------');
+    const instrs = compile_program(program);
+    log('--------------------------------------------');
+    log('Compiled program:');
+    log(instrs);
+    log('--------------------------------------------');
+    return assemble(instrs);
+}

--- a/std/ooga-std.ooga
+++ b/std/ooga-std.ooga
@@ -1,0 +1,30 @@
+// The Ooga Standard Library
+
+
+// Formatting
+type format struct {
+}
+
+func (f *format) Println(x any) {
+    print(x)
+}
+
+// Concurrency
+type WaitGroup struct {
+    counter int
+}
+
+func (wg *WaitGroup) Add(delta int) {
+    wg.counter += delta
+}
+
+func (wg *WaitGroup) Done() {
+    wg.counter--
+}
+
+func (wg *WaitGroup) Wait() {
+    for wg.counter > 0 {
+    }
+}
+
+var fmt format = format{}


### PR DESCRIPTION
This PR adds the Ooga standard library extension to our user programs and separates the preparation and compilation of the program from the main entry point.

The toolchain file is required because if you refactor the common logic of preparing and compiling the program into an exportable function, main itself will be run and will cause tooga and other utilities to fail.

We also parse the program and the ooga standard library separately then treat the user program as a block statement at the end of the ooga standard library's sequence statement.
