### PR TITLE
Optimise waitgroup

### DIFF
--- a/src/parser/ooga.pegjs
+++ b/src/parser/ooga.pegjs
@@ -1005,7 +1005,6 @@ FunctionDeclaration
       };
     }
 
-// Arnav: Not sure what this is for!!
 FunctionExpression
   = FunctionToken __ id:(Identifier __)?
     "(" __ params:(FormalParameterList __)? ")" __

--- a/src/vm/oogavm-typechecker.ts
+++ b/src/vm/oogavm-typechecker.ts
@@ -117,6 +117,7 @@ const global_type_frame = {
     startAtomic: new FunctionType([], new NullType()),
     endAtomic: new FunctionType([], new NullType()),
     yieldThread: new FunctionType([], new NullType()),
+    blockThread: new FunctionType([], new NullType()),
     getThreadID: new FunctionType([], new IntegerType()),
     oogaError: new FunctionType([], new NullType()),
 };

--- a/std/ooga-std.ooga
+++ b/std/ooga-std.ooga
@@ -24,6 +24,7 @@ func (wg *WaitGroup) Done() {
 
 func (wg *WaitGroup) Wait() {
     for wg.counter > 0 {
+        yieldThread(); // yield to avoid wasteful loop
     }
 }
 
@@ -45,7 +46,7 @@ func (m *Mutex) Lock() {
         }
         // else
         endAtomic();
-        yieldThread(); // block and loop until can pick up lock
+        blockThread(); // block and loop until can pick up lock
     }
     m.currentThread = getThreadID();
     endAtomic();


### PR DESCRIPTION
To avoid doing wasteful computation, I introduce a yieldThreadState and a blockThreadState. Both of this achieve the same thing except that yieldThread times out the thread while blockThread blocks the thread. This signals two different things to the deadlock detector to avoid false positives.
This also speeds up the standard library implementation of the WaitGroup since we no longer pointlessly iterate until the TimeQuanta for the thread reaches 0.