### PR TITLE
Throw error when division by 0

### DIFF
--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -1970,3 +1970,12 @@ for i := 0; i < len(arr); i++ {
 }
 0;
 `, 0, '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n', defaultNumWords);
+
+// Test for division by zero
+testProgram(`
+func foo() int {
+    return 0;
+}
+
+5 / foo();
+`, 'Division by 0 error!', '', defaultNumWords);

--- a/src/vm/oogavm-machine.ts
+++ b/src/vm/oogavm-machine.ts
@@ -75,7 +75,7 @@ import {
     Unassigned,
     Undefined,
 } from './oogavm-heap.js';
-import { OogaError } from './oogavm-errors.js';
+import { OogaError, RuntimeError } from './oogavm-errors.js';
 import { unparse } from '../utils/utils.js';
 import { appendHeap, appendStack } from '../server/debug.js';
 
@@ -353,6 +353,9 @@ function apply_binop(sym: string, left: any, right: any) {
         case '*':
             return left * right;
         case '/':
+            if (right === 0) {
+                throw new RuntimeError("Division by 0 error!");
+            }
             return left / right;
         default:
             // FIXME: Propagate error properly to the VM


### PR DESCRIPTION
Simply throw a RunTime error when the right operand is 0 for a division operator