### PR TITLE
Add time.Sleep()

### DIFF
--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -477,7 +477,7 @@ x;
 `,
     5,
     '',
-    300
+    400
 );
 
 // Testing mark and sweep, with exactly one variable that should be freed
@@ -497,7 +497,7 @@ x;
 `,
     5,
     '',
-    220
+    400
 );
 
 // Testing structs (no methods for now)
@@ -1044,7 +1044,7 @@ go googa(x, y);
 `,
     true,
     '15',
-    206
+    400
 );
 
 // Test various array expressions

--- a/src/vm/oogavm-machine.ts
+++ b/src/vm/oogavm-machine.ts
@@ -1267,7 +1267,6 @@ export function run(numWords = 1000000) {
     log('Program value is ' + returnValue);
     log('After STD initialization: ');
     printHeapUsage();
-    console.log("Return value is " + returnValue);
     debugHeap();
     log('Return value: ' + returnValue);
     return returnValue;

--- a/src/vm/oogavm-machine.ts
+++ b/src/vm/oogavm-machine.ts
@@ -307,9 +307,10 @@ export const builtinMappings = {
         isAtomicSection = false;
         return True;
     },
-    // "make": () => {
-    //   // TODO: Support channels as priority number 1
-    // }
+    getTime: () => {
+        // Get unix time in millis
+        return TSValueToAddress(Date.now());
+    }
 };
 
 class Builtin {
@@ -1245,7 +1246,6 @@ function runInstruction() {
     // printStringPoolMapping();
 }
 
-// TODO: Switch to low level memory representation
 export function run(numWords = 1000000) {
     initialize(numWords);
     while (running) {
@@ -1267,6 +1267,8 @@ export function run(numWords = 1000000) {
     log('Program value is ' + returnValue);
     log('After STD initialization: ');
     printHeapUsage();
+    console.log("Return value is " + returnValue);
+    debugHeap();
     log('Return value: ' + returnValue);
     return returnValue;
 }

--- a/src/vm/oogavm-typechecker.ts
+++ b/src/vm/oogavm-typechecker.ts
@@ -120,6 +120,7 @@ const global_type_frame = {
     blockThread: new FunctionType([], new NullType()),
     getThreadID: new FunctionType([], new IntegerType()),
     oogaError: new FunctionType([], new NullType()),
+    getTime: new FunctionType([], new IntegerType()),
 };
 
 const empty_type_environment = null;

--- a/std/ooga-std.ooga
+++ b/std/ooga-std.ooga
@@ -63,3 +63,19 @@ func (m *Mutex) Unlock() {
 }
 
 var fmt format = format{}
+
+
+type Time struct {
+}
+
+// Duration to sleep for in milliseconds
+func (t *Time) Sleep(duration int) {
+    startTime := getTime();
+    for {
+        if getTime() - startTime >= duration {
+            break;
+        }
+    }
+}
+
+var time Time = Time{};


### PR DESCRIPTION
Adds the time.Sleep(duration) in milliseconds standard library implementation.

Tested with time yarn booga on 

```go
time.Sleep(10000);
```

![image](https://github.com/CS4215-OOGA/ooga-lang/assets/45916998/849ea1c2-1324-40f0-b452-092cbfe4bd46)
